### PR TITLE
perf(settings): cache settings card entity list

### DIFF
--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -266,30 +266,36 @@ class LandroidCard extends LitElement {
    * @return {string[]} The list of entities to be displayed as settings in the card.
    */
   get settingsCardEntities() {
-    // 2026.4.0 Automigration: settings → settings_card
+    if (
+      this.__settingsCache?.hass === this.hass &&
+      this.__settingsCache?.config === this.config
+    ) {
+      return this.__settingsCache.result;
+    }
+
     const configured = this.config?.settings_card || this.config?.settings;
+    let result = null;
 
-    // Если пользователь явно задал список — используем его
-    if (configured?.length) return configured;
+    if (configured?.length) {
+      result = configured;
+    } else {
+      const deviceId = this.hass?.entities?.[this.config.entity]?.device_id;
+      if (deviceId && this.hass?.entities) {
+        const entities = this._deviceEntities
+          .filter(
+            (e) =>
+              e.entity_category === 'config' &&
+              this.hass.states[e.entity_id] &&
+              this.hass.states[e.entity_id].state !== consts.UNAVAILABLE,
+          )
+          .map((e) => e.entity_id)
+          .sort();
+        result = entities.length ? entities : null;
+      }
+    }
 
-    // Иначе — динамический сбор по entity_category === 'config'
-    const registryEntity = this.hass?.entities?.[this.config.entity];
-    const deviceId = registryEntity?.device_id;
-
-    if (!deviceId || !this.hass?.entities) return null;
-
-    const entities = Object.values(this.hass.entities)
-      .filter(
-        (e) =>
-          e.device_id === deviceId &&
-          e.entity_category === 'config' &&
-          this.hass.states[e.entity_id] &&
-          this.hass.states[e.entity_id].state !== consts.UNAVAILABLE,
-      )
-      .map((e) => e.entity_id)
-      .sort();
-
-    return entities.length ? entities : null;
+    this.__settingsCache = { hass: this.hass, config: this.config, result };
+    return result;
   }
 
   /**


### PR DESCRIPTION
- avoid recomputing on each render
- use internal cache keyed by hass and config
- fallback to dynamic entity discovery when not configured