### PR TITLE
feat: add device_class fallback for non-Landroid integrations

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -108,6 +108,29 @@ export const CARD_MAP = {
   },
 };
 
+// Fallback grouping for integrations that don't use Landroid Cloud translation
+// keys (e.g. Mammotion, Husqvarna Automower, Navimow).
+// When translation_key lookup returns no entities, card slots are filled by
+// matching sensor device_class against these lists.
+export const DEVICE_CLASS_MAP = {
+  [BATTERYCARD]: [
+    'battery', // battery level %
+    'voltage', // battery voltage
+    'current', // charging current
+  ],
+  [INFOCARD]: [
+    'signal_strength', // wifi / ble rssi
+    'duration', // elapsed_time, total_time, blade runtime, etc.
+    'timestamp', // next_schedule, error timestamps
+    'distance', // blade height, maintenance distance
+    'speed', // mowing speed
+  ],
+  [STATISTICSCARD]: [
+    // Statistics sensors rarely have a standard device_class;
+    // users are expected to configure this card manually via statistics_card.
+  ],
+};
+
 // States
 // Landroid Cloud States
 export const STATE_EDGECUT = 'edgecut';

--- a/src/landroid-card-editor.js
+++ b/src/landroid-card-editor.js
@@ -1,7 +1,7 @@
 import { LitElement, html, nothing } from 'lit';
 import { fireEvent } from 'custom-card-helpers';
 import { defaultConfig } from './defaults';
-import { CARD_MAP } from './constants';
+import { CARD_MAP, DEVICE_CLASS_MAP } from './constants';
 import style from './style-editor';
 import localize from './localize';
 
@@ -56,17 +56,36 @@ export default class LandroidCardEditor extends LitElement {
       (e) => e.device_id === deviceId,
     );
 
-    return translationKeys
+    const byTK = translationKeys
       .map((key) => {
         const found = deviceEntities.find((e) => e.translation_key === key);
         if (!found) return null;
-        // Не включаем unavailable
         const stateObj = this.hass.states[found.entity_id];
         return stateObj && stateObj.state !== 'unavailable'
           ? found.entity_id
           : null;
       })
       .filter(Boolean);
+
+    if (byTK.length > 0) return byTK;
+
+    // Fallback: device_class
+    const dcList = DEVICE_CLASS_MAP[cardType] ?? [];
+    if (!dcList.length) return [];
+
+    return Object.values(this.hass.entities)
+      .filter((e) => {
+        if (e.device_id !== deviceId) return false;
+        const stateObj = this.hass.states[e.entity_id];
+        if (!stateObj || stateObj.state === 'unavailable') return false;
+        const dc =
+          stateObj.attributes.device_class ??
+          e.device_class ??
+          e.original_device_class;
+        return dc && dcList.includes(dc);
+      })
+      .map((e) => e.entity_id)
+      .sort();
   }
 
   /**

--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -316,13 +316,21 @@ class LandroidCard extends LitElement {
     const result = Object.fromEntries(
       Object.entries(consts.CARD_MAP).map(([cardType, card]) => {
         const configured = this.config?.[cardType + '_card'];
-        const entities = configured?.length
-          ? configured.filter(
-              (id) =>
-                this.hass.states[id] &&
-                this.hass.states[id].state !== consts.UNAVAILABLE,
-            )
-          : this.findEntitiesByTranslationKeys(card.translationKeys);
+        let entities;
+        if (configured?.length) {
+          entities = configured.filter(
+            (id) =>
+              this.hass.states[id] &&
+              this.hass.states[id].state !== consts.UNAVAILABLE,
+          );
+        } else {
+          entities = this.findEntitiesByTranslationKeys(card.translationKeys);
+          if (entities.length === 0) {
+            entities = this.findEntitiesByDeviceClass(
+              consts.DEVICE_CLASS_MAP[cardType] ?? [],
+            );
+          }
+        }
         return [cardType, { entities, labelPosition: card.labelPosition }];
       }),
     );
@@ -688,6 +696,40 @@ class LandroidCard extends LitElement {
       const stateObj = this.hass.states[found.entity_id];
       if (stateObj && stateObj.state !== consts.UNAVAILABLE) {
         result.push(found.entity_id);
+      }
+      return result;
+    }, []);
+  }
+
+  /**
+   * Finds entities associated with the device that match the given device classes.
+   * Used as a fallback when translation_key lookup returns no results —
+   * typically for non-Landroid integrations (e.g. Mammotion, Husqvarna Automower).
+   *
+   * The device_class is resolved in the following priority order:
+   * 1. `state_obj.attributes.device_class` (runtime state)
+   * 2. `entity_registry.device_class` (user override)
+   * 3. `entity_registry.original_device_class` (integration default)
+   *
+   * @param {string[]} deviceClasses - List of device class strings to match against,
+   *   e.g. `['battery', 'voltage']`. Returns an empty array if the list is empty.
+   * @return {string[]} Array of entity IDs whose device_class matches one of the
+   *   provided values. Excludes unavailable entities.
+   */
+  findEntitiesByDeviceClass(deviceClasses) {
+    if (!deviceClasses.length) return [];
+    const deviceEntities = this._deviceEntities;
+    return deviceEntities.reduce((result, e) => {
+      const stateObj = this.hass.states[e.entity_id];
+      if (!stateObj || stateObj.state === consts.UNAVAILABLE) return result;
+
+      const dc =
+        stateObj.attributes.device_class ??
+        e.device_class ??
+        e.original_device_class;
+
+      if (dc && deviceClasses.includes(dc)) {
+        result.push(e.entity_id);
       }
       return result;
     }, []);


### PR DESCRIPTION
Auto-discover battery/info sensors by device_class when translation_key lookup returns no results. Works out of the box for Mammotion, Husqvarna Automower, Navimow and any other lawn_mower integration with standard HA sensor device classes.