### PR TITLE
refactor(card): simplify config defaults handling

### DIFF
--- a/src/defaults.js
+++ b/src/defaults.js
@@ -3,18 +3,18 @@ export const DEFAULT_LANG = 'en';
 export const defaultConfig = {
   // entity: '',
   // camera: '',
-  // camera_view: 'auto',    // 'auto' | 'live'
-  // camera_controls: false,
-  // camera_sound: false,
-  // image: 'default',
+  camera_view: 'auto',    // 'auto' | 'live'
+  camera_controls: false,
+  camera_muted: true,
+  image: 'default',
   image_size: 4,
-  // image_left: false,
-  // show_name: true,
+  image_left: false,
+  show_name: true,
   show_status: true,
   show_toolbar: true,
   show_edgecut: true,
   show_animation: true,
-  // compact_view: false,
+   compact_view: false,
   // Гибридные карточки — undefined = используются дефолты из CARD_MAP
   // battery_card: undefined,
   // info_card: undefined,

--- a/src/landroid-card-editor.js
+++ b/src/landroid-card-editor.js
@@ -26,10 +26,9 @@ export default class LandroidCardEditor extends LitElement {
    * @return {void} This function does not return anything.
    */
   setConfig(config) {
-    const newConfig = { ...defaultConfig, ...config };
+    const newConfig = { ...config };
 
     const lawnMowerEntities = this.entities() || [];
-
     if (!newConfig.entity && lawnMowerEntities.length > 0) {
       newConfig.entity = lawnMowerEntities[lawnMowerEntities.length - 1];
     }
@@ -260,11 +259,10 @@ export default class LandroidCardEditor extends LitElement {
       <ha-selector
         .label=${localize('editor.' + configValue)}
         .selector=${{ boolean: {} }}
-        .value=${this.config?.[configValue] ?? false}
+        .value=${this.config?.[configValue] ?? defaultConfig[configValue] ?? false}
         @value-changed=${(e) => {
           if (!this._firstRendered) return;
-          this.config = { ...this.config, [configValue]: e.detail.value };
-          fireEvent(this, 'config-changed', { config: this.config });
+          this.setConfigValue(configValue, e.detail.value);
         }}
       ></ha-selector>
     `;
@@ -362,11 +360,10 @@ export default class LandroidCardEditor extends LitElement {
                             mode: 'dropdown',
                           },
                         }}
-                        .value=${this.config.camera_view ?? 'auto'}
+                        .value=${this.config.camera_view ?? defaultConfig.camera_view}
                         @value-changed=${(e) => {
                           if (!this._firstRendered) return;
-                          this.config = { ...this.config, camera_view: e.detail.value };
-                          fireEvent(this, 'config-changed', { config: this.config });
+                          this.setConfigValue('camera_view', e.detail.value);
                         }}
                       ></ha-selector>
                     </div>
@@ -467,6 +464,17 @@ export default class LandroidCardEditor extends LitElement {
         };
       }
     }
+    fireEvent(this, 'config-changed', { config: this.config });
+  }
+
+  setConfigValue(key, value) {
+    const newConfig = { ...this.config };
+    if (value === (defaultConfig[key] ?? false)) {
+      delete newConfig[key];
+    } else {
+      newConfig[key] = value;
+    }
+    this.config = newConfig;
     fireEvent(this, 'config-changed', { config: this.config });
   }
 }

--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -153,15 +153,15 @@ class LandroidCard extends LitElement {
   }
 
   get cameraView() {
-  return this.config?.camera_view ?? 'auto';
+  return this.config?.camera_view ?? defaultConfig.camera_view;
   }
 
   get cameraControls() {
-    return this.config?.camera_controls ?? false;
+    return this.config?.camera_controls ?? defaultConfig.camera_controls;
   }
 
   get cameraMuted() {
-    return this.config?.camera_muted ?? true;
+    return this.config?.camera_muted ?? defaultConfig.camera_muted;
   }
 
   /**
@@ -172,8 +172,8 @@ class LandroidCard extends LitElement {
    * @return {string} The URL of the image to display on the card.
    */
   get image() {
-    const { image = 'default' } = this.config;
-    return image === 'default' ? defaultImage : image;
+    const image = this.config?.image ?? defaultConfig.image;
+    return !image || image === 'default' ? defaultImage : image;
   }
 
   /**
@@ -184,8 +184,7 @@ class LandroidCard extends LitElement {
    * @return {number} The size of the image in pixels.
    */
   get imageSize() {
-    const { image_size: imageSize = 4 } = this.config;
-    return imageSize * 50;
+    return (this.config?.image_size ?? defaultConfig.image_size) * 50;
   }
 
   /**
@@ -196,78 +195,79 @@ class LandroidCard extends LitElement {
    * @return {string} A CSS style string to position the image on the left or not.
    */
   get imageLeft() {
-    return this.config.image_left ? 'float: left;' : '';
+    return (this.config?.image_left ?? defaultConfig.image_left) ? 'float: left;' : '';
   }
 
   /**
    * Returns whether or not to show the animation on the card.
    * If the user has not specified the 'show_animation' option in the config,
-   * this function returns true (i.e. the animation is shown).
+   * this function returns default value.
    * Otherwise, this function returns the value of the 'show_animation' option.
    *
    * @return {boolean} Whether or not to show the animation on the card.
    */
   get showAnimation() {
-    return this.config?.show_animation ?? true;
+    return this.config?.show_animation ?? defaultConfig.show_animation;
   }
 
   /**
    * Returns whether or not the card should be in compact view mode.
-   * If the user has specified 'compact_view: true' in the config, this function returns true.
+   * If the user has specified 'compact_view: true' in the config,
+   * this function returns default value.
    * Otherwise, this function returns false.
    *
    * @return {boolean} Whether or not the card should be in compact view mode.
    */
   get compactView() {
-    return this.config?.compact_view ?? false;
+    return this.config?.compact_view ?? defaultConfig.compact_view;
   }
 
   /**
    * Returns whether or not to show the name of the Landroid on the card.
    * If the user has not specified the 'show_name' option in the config,
-   * this function returns false (i.e. the name is not shown).
+   * this function returns default value.
    * Otherwise, this function returns the value of the 'show_name' option.
    *
    * @return {boolean} Whether or not to show the name of the Landroid on the card.
    */
   get showName() {
-    return this.config?.show_name ?? false;
+    return this.config?.show_name ?? defaultConfig.show_name;
   }
 
   /**
    * Returns whether or not to show the status of the Landroid on the card.
    * If the user has not specified the 'show_status' option in the config,
-   * this function returns true (i.e. the status is shown).
+   * this function returns default value.
    * Otherwise, this function returns the value of the 'show_status' option.
    *
    * @return {boolean} Whether or not to show the status of the Landroid on the card.
    */
   get showStatus() {
-    return this.config?.show_status ?? true;
+    return this.config?.show_status ?? defaultConfig.show_status;
   }
 
   /**
    * Returns whether or not to show the edgecut button on the card.
    * If the user has not specified the 'show_edgecut' option in the config,
-   * this function returns true (i.e. the edgecut button is shown).
+   * this function returns default value.
    * Otherwise, this function returns the value of the 'show_edgecut' option.
    *
    * @return {boolean} Whether or not to show the edgecut button on the card.
    */
   get showEdgecut() {
-    return this.config?.show_edgecut ?? true;
+    return this.config?.show_edgecut ?? defaultConfig.show_edgecut;
   }
 
   /**
    * Returns whether or not to show the toolbar on the card.
    * If the user has not specified the 'show_toolbar' option in the config,
-   * this function returns true (i.e. the toolbar is shown).
+   * this function returns default value.
    * Otherwise, this function returns the value of the 'show_toolbar' option.
    *
    * @return {boolean} Whether or not to show the toolbar on the card.
    */
   get showToolbar() {
-    return this.config?.show_toolbar ?? true;
+    return this.config?.show_toolbar ?? defaultConfig.show_toolbar;
   }
 
   /**
@@ -392,13 +392,10 @@ class LandroidCard extends LitElement {
       console.warn(localize('warning.actions_array'));
     }
 
-    this.config = {
-      ...defaultConfig,
-      ...config,
-    };
+    this.config = { ...config, };
+
     // Инициализируем все карточки как скрытые
     this._activeCard = null;
-
     this._huiCardCache = new Map(); // сброс кеша при новом конфиге
   }
 


### PR DESCRIPTION
- remove redundant spreading of defaultConfig in editor and card
- add helper to unset values matching defaults
- update getters to fallback to defaultConfig constants