### PR TITLE
**fix: prevent memory leak by limiting `_huiCardCache` size**

### DIFF
--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -394,6 +394,8 @@ class LandroidCard extends LitElement {
    * @return {void} This function does not return anything.
    */
   setConfig(config) {
+    this._huiCardCache?.clear?.();
+
     if (!config.entity && !config._preview) {
       throw new Error(localize('error.missing_entity'));
     }
@@ -1026,6 +1028,10 @@ class LandroidCard extends LitElement {
    * @return {HuiEntitiesCardElement} The hui-entities-card element.
    */
   createHuiCardElement(config) {
+    if (this._huiCardCache.size > 10) {
+      const firstKey = this._huiCardCache.keys().next().value;
+      this._huiCardCache.delete(firstKey);
+    }
     const key = JSON.stringify(config.entities.map((e) => e.entity));
 
     if (this._huiCardCache.has(key)) {


### PR DESCRIPTION
- Cleared `_huiCardCache` at the beginning of `setConfig()` to ensure unused DOM elements are garbage collected during UI edits.
- Added a maximum size limit (e.g., 10 entries) to the cache in `createHuiCardElement()` using a FIFO approach to prevent unbounded memory growth.
- This resolves potential "Out of Memory" browser crashes caused by detached DOM elements when actively modifying the card configuration in the Home Assistant visual editor.