### PR TITLE
fix(action): add error handling to handleAction

### DIFF
--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -598,14 +598,20 @@ class LandroidCard extends LitElement {
    * @param {string} [params.defaultService] - The service to call if the action is not found in the actions config object.
    * @return {Function} The function to call to trigger the action.
    */
-  handleAction(e, action, params = {}) {
-    const actions = this.config.actions || {};
-    const { defaultService = action, ...service_data } = params;
-    delete service_data.action;
-
-    actions[action]
-      ? this.callAction(actions[action])
-      : this.callService(e, defaultService, service_data);
+  async handleAction(e, action, params = {}) {
+    try {
+      const actions = this.config.actions || {};
+      const { defaultService = action, ...service_data } = params;
+      delete service_data.action;
+      actions[action]
+        ? await this.callAction(actions[action])
+        : await this.callService(e, defaultService, service_data);
+    } catch (err) {
+      console.error('LANDROID-CARD: handleAction failed:', err);
+      fireEvent(this, 'hass-notification', {
+        message: `Landroid Card: ${err?.message ?? String(err)}`,
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
The `handleAction` method in `landroid-card.js` was updated from a synchronous function to an async one. Key changes:
- Wrapped the logic in a `try/catch` block to capture any runtime errors.
- Added `console.error` logging for debugging.
- Emitted a `hass-notification` event with the error message so users receive feedback in Home Assistant.
- Awaited `callAction` and `callService` calls to ensure proper promise handling.

These changes prevent unhandled promise rejections, provide clearer error visibility, and improve the user experience when an action fails.