### PR TITLE
feat(card): add support for vacuum domain

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -1,5 +1,6 @@
 // Services
 export const LAWNMOWER_SERVICE = 'lawn_mower';
+export const VACUUM_SERVICE = 'vacuum';
 export const ACTION_MOWING = 'start_mowing';
 export const ACTION_PAUSE = 'pause';
 export const ACTION_DOCK = 'dock';

--- a/src/landroid-card-editor.js
+++ b/src/landroid-card-editor.js
@@ -279,7 +279,7 @@ export default class LandroidCardEditor extends LitElement {
     const schema = [
       {
         name: 'entity',
-        selector: { entity: { domain: 'lawn_mower' } },
+        selector: { entity: { domain: ["lawn_mower", "vacuum"] } },
       },
       {
         name: 'camera',

--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -1199,7 +1199,8 @@ window.customCards.push({
   documentationURL: 'https://github.com/Barma-lej/landroid-card',
   // Landroid card suggestions in the card picker based on entity domain and/or integration
   getEntitySuggestion: (hass, entityId) => {
-    if (entityId.split(".")[0] !== "lawn_mower") {
+    const domain = entityId.split(".")[0];
+    if (domain !== "lawn_mower" && domain !== "vacuum") {
       return null;
     }
     return {


### PR DESCRIPTION
Add a new constant for the vacuum service and extend the card editor and suggestion logic to handle vacuum entities. The editor’s entity selector now accepts both lawn_mower and vacuum domains, and the card picker will recognize vacuum entities in addition to lawn_mowers. This change enables the Landroid card to work with vacuum devices, expanding its usability across more Home Assistant integrations.