### PR TITLE
refactor(toolbar): update start/dock button logic and constants

### DIFF
--- a/src/constants.js
+++ b/src/constants.js
@@ -9,6 +9,7 @@ export const ACTION_DOCK = 'dock';
 export const ACTION_EDGECUT = 'edgecut';
 
 // Vacuum services
+export const ACTION_TURN_ON = 'turn_on';
 export const ACTION_STOP = 'stop';
 export const ACTION_FAN_SPEED = 'set_fan_speed';
 export const ACTION_LOCATE = 'locate';
@@ -19,6 +20,10 @@ export const ACTION_BUTTONS = {
   [ACTION_START]: {
     icon: 'mdi:play',
     action: LAWNMOWER_SERVICE + '.' + ACTION_START,
+  },
+  [ACTION_TURN_ON]: {
+    icon: 'mdi:play',
+    action: LAWNMOWER_SERVICE + '.' + ACTION_TURN_ON,
   },
   [ACTION_EDGECUT]: {
     icon: 'mdi:motion-play',
@@ -61,6 +66,7 @@ export const DOMAIN_SERVICE_MAP = {
     [ACTION_DOCK]: 'dock',
   },
   [VACUUM_SERVICE]: {
+    [ACTION_TURN_ON]: 'turn_on',
     [ACTION_START]: 'start',
     [ACTION_STOP]: 'stop',
     [ACTION_PAUSE]: 'pause',
@@ -73,13 +79,13 @@ export const DOMAIN_SERVICE_MAP = {
 
 // Битмаски supported_features (HA: LawnMowerEntityFeature / VacuumEntityFeature)
 export const DOMAIN_FEATURES = {
-  [LAWNMOWER_SERVICE]: { START_MOWING: 1, PAUSE: 2, DOCK: 4 },
+  [LAWNMOWER_SERVICE]: { START: 1, PAUSE: 2, DOCK: 4 }, // START = START_MOWING
   [VACUUM_SERVICE]: {
     TURN_ON:  1,
     TURN_OFF: 2,
     PAUSE: 4,
     STOP: 8,
-    RETURN_HOME: 16,
+    DOCK: 16, // DOCK = RETURN_HOME
     FAN_SPEED: 32,
     BATTERY: 64,
     STATUS: 128,

--- a/src/elements/lc-toolbar.js
+++ b/src/elements/lc-toolbar.js
@@ -98,15 +98,17 @@ class LandroidToolbar extends LitElement {
     const { state, showEdgecut } = this;
 
     const startBtn = (label) =>
-      this._can('START') || this._can('START_MOWING')
+      this._can('START')
         ? html`<lc-button .label=${label} .entityId=${this.entityId} action=${consts.ACTION_START}></lc-button>`
-        : nothing;
+        : this._can('TURN_ON')
+          ? html`<lc-button .label=${label} .entityId=${this.entityId} action=${consts.ACTION_TURN_ON}></lc-button>`
+          : nothing;
     const pauseBtn = (label) =>
       this._can('PAUSE')
         ? html`<lc-button .label=${label} .entityId=${this.entityId} action=${consts.ACTION_PAUSE}></lc-button>`
         : nothing;
     const dockBtn = (label) =>
-      this._can('DOCK') || this._can('RETURN_HOME')
+      this._can('DOCK')
         ? html`<lc-button .label=${label} .entityId=${this.entityId} action=${consts.ACTION_DOCK}></lc-button>`
         : nothing;
     const stopBtn = (label) =>
@@ -151,8 +153,10 @@ class LandroidToolbar extends LitElement {
       case consts.STATE_ESCAPED_DIGITAL_FENCE:
         return html`${dockBtn(false)}${stopBtn(false)}${locateBtn(false)}`;
 
-      default:
-        return html`${startBtn(false)}${edgecutBtn(false)}`;
+      default: // consts.STATE_DOCKED, consts.STATE_IDLE, consts.STATE_RAINDELAY:
+        return html`${startBtn(false)}${edgecutBtn(false)}
+        ${ consts.STATE_IDLE === state ? dockBtn(false) : nothing }
+        ${locateBtn(false)}${cleanSpotBtn(false)}`;
     }
   }
 


### PR DESCRIPTION
The constants for the vacuum domain were updated to match the new Home Assistant feature names:
- Added `ACTION_TURN_ON` mapping for the vacuum service.
- Renamed `START_MOWING` to `START` and `RETURN_HOME` to `DOCK` in `DOMAIN_FEATURES`.

The toolbar component was refactored to use the updated constants and improve button rendering:
- The start button now checks only for `START` and falls back to a `TURN_ON` button if the entity can be turned on.
- The dock button now checks only for `DOCK`, removing the old `RETURN_HOME` check.
- The default button set now includes a dock button when the state is idle, and always shows locate and clean‑spot buttons.

These changes bring the UI in line with the updated feature set