### PR TITLE
style(landroid-card): remove redundant semicolon

### DIFF
--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -1135,7 +1135,7 @@ class LandroidCard extends LitElement {
   renderStatus() {
     if (!this.showStatus) return nothing;
 
-    const state = this.entity?.state;;
+    const state = this.entity?.state;
 
     // Все опциональные сущности — если нет, просто undefined
     const zoneSensor = this.getEntityByTranslationKey(consts.TK_SELECT_ZONE);


### PR DESCRIPTION
The renderStatus method contained an extra semicolon after accessing the entity state. This redundant semicolon is unnecessary and can trigger linting warnings. Removing it cleans up the code and ensures consistent formatting across the project without affecting functionality.