### PR TITLE
chore(version): bump to 2026.9.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "landroid-card",
-  "version": "2026.8.1",
+  "version": "2026.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "landroid-card",
-      "version": "2026.8.1",
+      "version": "2026.9.0",
       "license": "MIT",
       "dependencies": {
         "custom-card-helpers": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "landroid-card",
-  "version": "2026.8.1",
+  "version": "2026.9.0",
   "description": "Landroid lawnmower card for Home Assistant Lovelace UI",
   "main": "dist/landroid-card.js",
   "type": "module",


### PR DESCRIPTION
Bumped the project version from 2026.8.1 to 2026.9.0 in both package.json and package-lock.json to align the manifest and lockfile for the new release. This ensures consistent versioning across dependencies and CI pipelines.