### PR TITLE
feat(card): add noopener noreferrer to window.open for url actions

### DIFF
--- a/src/card/actions-mixin.js
+++ b/src/card/actions-mixin.js
@@ -142,7 +142,11 @@ export const ActionsMixin = (superClass) =>
           break;
 
         case 'url':
-          window.open(action.url_path, action.url_target ?? '_blank');
+          window.open(
+            action.url_path,
+            action.url_target ?? '_blank',
+            'noopener,noreferrer',
+          );
           break;
 
         case 'more-info':


### PR DESCRIPTION
Added the 'noopener,noreferrer' third argument to the `window.open` call in the `url` case, providing security by preventing the newly opened page from accessing the originating window and mitigating tabnabbing risks.