### PR TITLE
refactor(LandroidCardEditor): remove unnecessary updated method

### DIFF
--- a/src/landroid-card-editor.js
+++ b/src/landroid-card-editor.js
@@ -107,13 +107,6 @@ export default class LandroidCardEditor extends LitElement {
     this._firstRendered = true;
   }
 
-  updated(changedProps) {
-    super.updated(changedProps);
-    if (!this._firstRendered) return;
-
-    fireEvent(this, 'ha-component-height', { height: 100 });
-  }
-
   /**
    * Renders a list of entities for the specified configuration key.
    * If the configuration key is not present in the component's configuration,


### PR DESCRIPTION
The `updated` method that fired a `ha-component-height` event after the first render was removed. This cleanup eliminates dead code and simplifies the component's lifecycle without affecting its functionality.