### PR TITLE
refactor(shouldUpdate): consolidate update checks and simplify logic

### DIFF
--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -270,34 +270,30 @@ class LandroidCard extends ActionsMixin(DiscoveryMixin(ImageMixin(LitElement))) 
    * @return {boolean} True if the component should update, false otherwise.
    */
   shouldUpdate(changedProps) {
-    if (
-      changedProps.has('config') ||
-      changedProps.has('_activeCard') ||
-      changedProps.has('showSettingsCard') ||
-      changedProps.has('requestInProgress') ||
-      changedProps.has('_resolvedImage') ||
-      changedProps.has('_haStateImageReady')
-    ) {
-      return true;
-    }
+    if (changedProps.has('config')) return true;
 
-    if (!changedProps.has('hass')) return false;
+    if (!changedProps.has('hass')) {
+      return Array.from(changedProps.keys()).some((key) => key !== 'hass');
+    }
 
     const oldHass = changedProps.get('hass');
     if (!oldHass) return true;
 
-    if (
-      oldHass.states[this.config.entity] !==
-      this.hass.states[this.config.entity]
-    ) {
+    // Реакция на смену темы оформления
+    if (oldHass.themes !== this.hass.themes) return true;
+    if (oldHass.selectedTheme !== this.hass.selectedTheme) return true;
+
+    // Реакция на смену языка и локали (форматы дат/чисел, переводы)
+    if (oldHass.language !== this.hass.language) return true;
+    if (oldHass.locale !== this.hass.locale) return true;
+
+    // Изменение основной сущности
+    if (oldHass.states[this.config?.entity] !== this.hass.states[this.config?.entity]) {
       return true;
     }
 
-    if (
-      this._entityIds?.some(
-        (id) => oldHass.states[id]?.state !== this.hass.states[id]?.state,
-      )
-    ) {
+    // Изменение вспомогательных сущностей (сенсоры, кнопки, шорткаты и т.д.)
+    if (this._entityIds?.some((id) => oldHass.states[id] !== this.hass.states[id])) {
       return true;
     }
 

--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -270,29 +270,49 @@ class LandroidCard extends ActionsMixin(DiscoveryMixin(ImageMixin(LitElement))) 
    * @return {boolean} True if the component should update, false otherwise.
    */
   shouldUpdate(changedProps) {
-    if (changedProps.has('config')) return true;
+    // 1. Внутренние реактивные свойства карточки и конфиг
+    if (
+      changedProps.has('config') ||
+      changedProps.has('_activeCard') ||
+      changedProps.has('showSettingsCard') ||
+      changedProps.has('requestInProgress') ||
+      changedProps.has('_resolvedImage') ||
+      changedProps.has('_haStateImageReady')
+    ) {
+      return true;
+    }
 
+    // 2. Если hass не менялся (или изменились любые другие свойства, кроме hass)
     if (!changedProps.has('hass')) {
-      return Array.from(changedProps.keys()).some((key) => key !== 'hass');
+      return false;
     }
 
     const oldHass = changedProps.get('hass');
     if (!oldHass) return true;
 
-    // Реакция на смену темы оформления
-    if (oldHass.themes !== this.hass.themes) return true;
-    if (oldHass.selectedTheme !== this.hass.selectedTheme) return true;
-
-    // Реакция на смену языка и локали (форматы дат/чисел, переводы)
-    if (oldHass.language !== this.hass.language) return true;
-    if (oldHass.locale !== this.hass.locale) return true;
-
-    // Изменение основной сущности
-    if (oldHass.states[this.config?.entity] !== this.hass.states[this.config?.entity]) {
+    // 3. Реакция на смену темы оформления
+    if (
+      oldHass.themes !== this.hass.themes ||
+      oldHass.selectedTheme !== this.hass.selectedTheme
+    ) {
       return true;
     }
 
-    // Изменение вспомогательных сущностей (сенсоры, кнопки, шорткаты и т.д.)
+    // 4. Реакция на смену языка и локали (форматы дат/чисел, тексты)
+    if (
+      oldHass.language !== this.hass.language ||
+      oldHass.locale !== this.hass.locale
+    ) {
+      return true;
+    }
+
+    // 5. Изменение состояния основной сущности
+    const entityId = this.config?.entity;
+    if (entityId && oldHass.states[entityId] !== this.hass.states[entityId]) {
+      return true;
+    }
+
+    // 6. Изменение вспомогательных сущностей (сенсоры, кнопки, шорткаты и т.д.)
     if (this._entityIds?.some((id) => oldHass.states[id] !== this.hass.states[id])) {
       return true;
     }


### PR DESCRIPTION
The shouldUpdate method was refactored to explicitly list the reactive properties that trigger an update, removing the previous generic check that returned false when hass was unchanged and iterated over all other keys. Now it directly returns false for unchanged hass and checks a focused set of properties (config, _activeCard, showSettingsCard, requestInProgress, _resolvedImage, _haStateImageReady). Additional dedicated checks were added for theme, language, locale, and the main entity state, each with clear comments. This makes the update detection more precise, improves readability, and eliminates unnecessary loops over changed properties.