### PR TITLE
feat(landroid-card): show missing entity error UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+dist/
 help/
 node_modules/
 node_modules_/
@@ -5,4 +6,3 @@ temp/
 versions/
 yarn.lock
 landroid-card.code-workspace
-dist/landroid-card.js

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -38,7 +38,7 @@ rl.question(
     execSync('npm run test', { stdio: 'inherit' });
 
     // 3. Коммит только если есть что коммитить (проверяем staged)
-    execSync('git add package.json dist/');
+    execSync('git add package.json');
     const staged = execSync('git diff --cached --name-only').toString().trim();
 
     if (staged) {

--- a/src/landroid-card-editor.js
+++ b/src/landroid-card-editor.js
@@ -26,7 +26,15 @@ export default class LandroidCardEditor extends LitElement {
    * @return {void} This function does not return anything.
    */
   setConfig(config) {
+    const hasPreview = '_preview' in config;
+
     this.config = { ...config };
+    delete this.config._preview;
+
+    // Если в конфиге из YAML был _preview — сразу шлём в HA чистый конфиг
+    if (hasPreview) {
+      fireEvent(this, 'config-changed', { config: this.config });
+    }
   }
 
   defaultEntitiesForCard(cardType) {

--- a/src/landroid-card.js
+++ b/src/landroid-card.js
@@ -91,19 +91,23 @@ class LandroidCard extends ActionsMixin(DiscoveryMixin(ImageMixin(LitElement))) 
   }
 
   /**
-   * Returns a default card configuration (without the type: parameter)
-   * in json form for use by the card type picker in the dashboard.
+   * Generates a default stub configuration when adding the card in the UI.
    *
-   * @param {object} hass - The Home Assistant instance.
-   * @param {array} entities - The list of entities.
-   * @return {object} The default card configuration configuration object with the entity and image properties.
+   * @param {Object} hass - Home Assistant instance.
+   * @param {Array<string>} entities - Entities present on the current dashboard view.
+   * @return {Object} The initial card configuration.
    */
-  static getStubConfig(hass, entities) {
-    const robotEntities = entities.filter(isSupportedEntity);
+  static getStubConfig(hass, entities = []) {
+    // 1. Сначала ищем среди сущностей текущего дашборда
+    let found = entities.find(isSupportedEntity);
+
+    // 2. Если на текущем виде косилки нет, ищем по всей системе Home Assistant
+    if (!found && hass?.states) {
+      found = Object.keys(hass.states).find(isSupportedEntity);
+    }
 
     return {
-      entity: robotEntities[0] || '',
-      _preview: !robotEntities.length, // флаг для setConfig
+      entity: found || '',
     };
   }
 
@@ -231,26 +235,21 @@ class LandroidCard extends ActionsMixin(DiscoveryMixin(ImageMixin(LitElement))) 
    * @param {Object} config - The configuration object to be set.
    * @throws {Error} If the configuration does not contain an 'entity' key.
    * @throws {Error} If the configuration contains an 'actions' key with an array value.
-   *                  The 'actions' key should be an object, not an array.
+   *                 The 'actions' key should be an object, not an array.
    * @return {void} This function does not return anything.
    */
   setConfig(config) {
     this._huiCardCache?.clear?.();
-
-    if (!config.entity && !config._preview) {
-      throw new Error(localize('error.missing_entity'));
-    }
 
     const actions = config.actions;
     if (actions && Array.isArray(actions)) {
       console.warn(localize('warning.actions_array'));
     }
 
-    this.config = { ...config, };
+    this.config = { ...config };
 
-    // Инициализируем все карточки как скрытые
     this._activeCard = null;
-    this._huiCardCache = new Map(); // сброс кеша при новом конфиге
+    this._huiCardCache = new Map();
   }
 
   /**
@@ -458,6 +457,16 @@ class LandroidCard extends ActionsMixin(DiscoveryMixin(ImageMixin(LitElement))) 
    * @return {TemplateResult} The rendered HTML template.
    */
   render() {
+    if (!this.entity) {
+      return html`
+        <ha-card>
+          <div style="padding: 16px; text-align: center; color: var(--secondary-text-color);">
+            ${localize('error.missing_entity')}
+          </div>
+        </ha-card>
+      `;
+    }
+
     // Режим превью — hass ещё не доступен
     if (!this.hass || !this.config?.entity) {
       return html`


### PR DESCRIPTION
feat(landroid-card): show missing entity error UI

The setConfig method in LandroidCardEditor now detects the _preview flag in the incoming configuration, removes it before storing the config, and only emits a config-changed event when a preview was present. This ensures Home Assistant receives a clean configuration without preview metadata.

In LandroidCard, getStubConfig was refactored to first look for a supported entity among the current dashboard's entities, and if none are found, to search the entire Home Assistant state map. The _preview flag was removed from the returned stub, simplifying default card generation.

The setConfig method in LandroidCard no longer validates the presence of entity or _preview, eliminating unnecessary error throws. It also clears the cache more cleanly and avoids a trailing comma in the spread operator, making configuration handling more permissive and robust.

Finally, the render method now returns an explicit error card with a localized message when entity is falsy, providing clear UI feedback to users who have not configured an entity. These changes improve configuration handling, remove redundant validation, and enhance the user experience.

fix(scripts): stop adding dist/ to git add

Previously the script staged both package.json and the dist/ directory, causing built artifacts to be included in commits. This change limits staging to package.json only, preventing dist/ from being committed. This ensures that only intended source changes are versioned and avoids committing generated files.